### PR TITLE
Rename some variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # mcptools (development version)
 
-`mcp_server()` gains argument `include_session_tools`, allowing users to opt-out of presenting R sessions tools to clients.
+`mcp_server()` gains logical argument `session_tools`, allowing users to opt-out of presenting R sessions tools to clients.
 
 # mcptools 0.1.1
 

--- a/R/server.R
+++ b/R/server.R
@@ -54,10 +54,11 @@
 #' @param tools Optional collection of tools to expose. Supply either a list
 #'   of objects created by [ellmer::tool()] or a path to an `.R` file that,
 #'   when sourced, yields such a list. Defaults to `NULL`, which serves only
-#'   the built-in session tools when `include_session_tools` is `TRUE`.
+#'   the built-in session tools when `session_tools` is `TRUE`.
 #' @param ... Reserved for future use; currently ignored.
-#' @param include_session_tools Logical. Include the built-in session tools
-#' (`list_r_sessions`, `select_r_session`) that work with `mcp_session()`. Defaults to `TRUE`.
+#' @param session_tools Logical value whether to include the built-in session
+#'   tools (`list_r_sessions`, `select_r_session`) that work with
+#'   `mcp_session()`. Defaults to `TRUE`.
 #'
 #' @returns
 #' `mcp_server()` and `mcp_session()` are both called primarily for side-effects.
@@ -104,12 +105,11 @@
 #'
 #' @name server
 #' @export
-mcp_server <- function(tools = NULL, ..., include_session_tools = TRUE) {
+mcp_server <- function(tools = NULL, ..., session_tools = TRUE) {
   # TODO: should this actually be a check for being called within Rscript or not?
   check_not_interactive()
-  set_server_tools(tools, include_session_tools)
-
-  the$do_sessions <- isTRUE(include_session_tools)
+  the$sessions_enabled <- isTRUE(session_tools)
+  set_server_tools(tools, session_tools = the$sessions_enabled)
 
   cv <- nanonext::cv()
 
@@ -118,7 +118,7 @@ mcp_server <- function(tools = NULL, ..., include_session_tools = TRUE) {
   nanonext::pipe_notify(reader_socket, cv, remove = TRUE, flag = TRUE)
   client <- nanonext::recv_aio(reader_socket, mode = "string", cv = cv)
 
-  if (!the$do_sessions) {
+  if (!the$sessions_enabled) {
     while (nanonext::wait(cv)) {
       if (!nanonext::unresolved(client)) {
         handle_message_from_client(client$data)
@@ -192,7 +192,7 @@ handle_message_from_client <- function(line) {
   } else if (data$method == "tools/call") {
     tool_name <- data$params$name
     if (
-      isFALSE(the$do_sessions) ||
+      !the$sessions_enabled ||
         # two tools provided by mcptools itself which must be executed in
         # the server rather than a session (#18)
         tool_name %in% c("list_r_sessions", "select_r_session") ||

--- a/R/tools.R
+++ b/R/tools.R
@@ -1,11 +1,11 @@
 set_server_tools <- function(
   x,
-  include_session_tools = TRUE,
+  session_tools = TRUE,
   x_arg = caller_arg(x),
   call = caller_env()
 ) {
   if (is.null(x)) {
-    if (include_session_tools) {
+    if (session_tools) {
       the$server_tools <- c(list(list_r_sessions_tool, select_r_session_tool))
       return()
     } else {
@@ -58,7 +58,7 @@ set_server_tools <- function(
     )
   }
 
-  if (include_session_tools) {
+  if (session_tools) {
     x <- c(
       x,
       list(

--- a/man/server.Rd
+++ b/man/server.Rd
@@ -6,7 +6,7 @@
 \alias{mcp_session}
 \title{R as a server: Configure R-based tools with LLM-enabled apps}
 \usage{
-mcp_server(tools = NULL, ..., include_session_tools = TRUE)
+mcp_server(tools = NULL, ..., session_tools = TRUE)
 
 mcp_session()
 }
@@ -14,12 +14,13 @@ mcp_session()
 \item{tools}{Optional collection of tools to expose. Supply either a list
 of objects created by \code{\link[ellmer:tool]{ellmer::tool()}} or a path to an \code{.R} file that,
 when sourced, yields such a list. Defaults to \code{NULL}, which serves only
-the built-in session tools when \code{include_session_tools} is \code{TRUE}.}
+the built-in session tools when \code{session_tools} is \code{TRUE}.}
 
 \item{...}{Reserved for future use; currently ignored.}
 
-\item{include_session_tools}{Logical. Include the built-in session tools
-(\code{list_r_sessions}, \code{select_r_session}) that work with \code{mcp_session()}. Defaults to \code{TRUE}.}
+\item{session_tools}{Logical value whether to include the built-in session
+tools (\code{list_r_sessions}, \code{select_r_session}) that work with
+\code{mcp_session()}. Defaults to \code{TRUE}.}
 }
 \value{
 \code{mcp_server()} and \code{mcp_session()} are both called primarily for side-effects.


### PR DESCRIPTION
Make `include_session_tools` -> `session_tools` less verbose.

Also `the$do_sessions` -> `the$sessions_enabled` as the former sounds like a function.

@t-kalinowski  targeting your branch, thanks!